### PR TITLE
Optimize move generation using bitboard iteration

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -9,54 +9,54 @@ vector<Move> Game::get_all_moves()
 {
     vector<Move> all_moves;
 
-    // Iterate through all pieces on the board
+    // Iterate through all piece bitboards
     for (int i = 0; i < 12; ++i)
     {
+        // Skip pieces that do not belong to the side to move
+        if ((this->whiteTurn && (i > 5)) || (!this->whiteTurn && (i < 6)))
+        {
+            continue;
+        }
+
+        // Copy the bitboard so we can modify it while iterating
         U64 board = (this->board).boards[i];
 
-        // Iterate through each square on the board
-        for (int j = 0; j < DIMENSION; ++j)
+        // Iterate over all set bits in the bitboard
+        while (board)
         {
-            for (int k = 0; k < DIMENSION; ++k)
+            int square = get_LSB(board); // index of least significant bit
+            board &= (board - 1);        // clear the least significant bit
+
+            int j = square / DIMENSION;
+            int k = square % DIMENSION;
+
+            vector<Move> piece_moves;
+
+            // Generate moves based on the type of piece
+            switch (i % 6)
             {
-                // Check if the current square contains a piece
-                if (get_bit(board, (j * DIMENSION + k)) == 1)
-                {
-                    string piece = (this->board).piece_map[i];
-
-                    // Generate moves based on the type of piece and the current turn
-                    vector<Move> piece_moves;
-
-                    if ((this->whiteTurn && i >= 0 && i <= 5) || (!this->whiteTurn && i >= 6 && i <= 11))
-                    {
-                        // Handle the case when the piece is a pawn, rook, knight, bishop, queen, or king
-                        switch (i % 6)
-                        {
-                        case 0: // Pawn
-                            piece_moves = this->get_pawn_moves(j, k);
-                            break;
-                        case 1: // Knight
-                            piece_moves = this->get_knight_moves(j, k);
-                            break;
-                        case 2: // Bishop
-                            piece_moves = this->get_bishop_moves(j, k);
-                            break;
-                        case 3: // Rook
-                            piece_moves = this->get_rook_moves(j, k);
-                            break;
-                        case 4: // Queen
-                            piece_moves = this->get_queen_moves(j, k);
-                            break;
-                        case 5: // King
-                            piece_moves = this->get_king_moves(j, k);
-                            break;
-                        }
-                    }
-
-                    // Append the generated moves to the list of all moves
-                    all_moves.insert(all_moves.end(), piece_moves.begin(), piece_moves.end());
-                }
+            case 0: // Pawn
+                piece_moves = this->get_pawn_moves(j, k);
+                break;
+            case 1: // Knight
+                piece_moves = this->get_knight_moves(j, k);
+                break;
+            case 2: // Bishop
+                piece_moves = this->get_bishop_moves(j, k);
+                break;
+            case 3: // Rook
+                piece_moves = this->get_rook_moves(j, k);
+                break;
+            case 4: // Queen
+                piece_moves = this->get_queen_moves(j, k);
+                break;
+            case 5: // King
+                piece_moves = this->get_king_moves(j, k);
+                break;
             }
+
+            // Append the generated moves to the list of all moves
+            all_moves.insert(all_moves.end(), piece_moves.begin(), piece_moves.end());
         }
     }
 


### PR DESCRIPTION
## Summary
- Refactor `Game::get_all_moves` to iterate over set bits in each piece bitboard, avoiding nested board scans and speeding up move generation.

## Testing
- `make chess_test`
- `./chess_test` *(fails: XDG_RUNTIME_DIR is invalid or not set in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_6897b15466b08333afcd167bffcee971